### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM quay.io/cdis/python:3.7-alpine as base
 
 FROM base as builder
 RUN apk add --no-cache --virtual .build-deps gcc musl-dev libffi-dev openssl-dev make postgresql-dev git curl
+RUN pip install --upgrade pip
 RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
 COPY . /src/
 WORKDIR /src


### PR DESCRIPTION
Fix docker build errors:
`network error (1 tries remaining): [6] Couldn't resolve host name (Could not resolve host: crates.io) warning: spurious network error (1 tries remaining): [6] Couldn't resolve host name (Could not resolve host: crates.io) error: failed to download from https://crates.io/api/v1/crates/bitflags/1.2.1/download Caused by: [6] Couldn't resolve host name (Could not resolve host: crates.io)`

### New Features


### Breaking Changes


### Bug Fixes


### Improvements
- upgrade pip in dockerfile

### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
