### PR TITLE
(PXP:8831): Add 'active' parameter to GET /request/user endpoint

### DIFF
--- a/src/requestor/routes/query.py
+++ b/src/requestor/routes/query.py
@@ -85,6 +85,9 @@ async def list_requests(
 async def list_user_requests(api_request: Request, auth=Depends(Auth)) -> dict:
     """
     List the current user's requests.
+
+    Use the "active" query parameter to get only those requests
+    created by the user that are not in DRAFT or FINAL statuses.
     """
     # no authz checks because we assume the current user can read
     # their own requests.

--- a/src/requestor/routes/query.py
+++ b/src/requestor/routes/query.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 from starlette.requests import Request
 from starlette.status import (
     HTTP_200_OK,
+    HTTP_400_BAD_REQUEST,
     HTTP_404_NOT_FOUND,
 )
 
@@ -18,13 +19,15 @@ from ..models import Request as RequestModel
 router = APIRouter()
 
 
-async def get_user_requests(username: str) -> list:
-    return [
-        r
-        for r in (
-            await RequestModel.query.where(RequestModel.username == username).gino.all()
+async def get_user_requests(username: str, active: bool = False) -> list:
+    query = RequestModel.query.where(RequestModel.username == username)
+    if active:
+        query = query.where(
+            RequestModel.status.notin_(
+                config["DRAFT_STATUSES"] + config["FINAL_STATUSES"]
+            )
         )
-    ]
+    return [r for r in (await query.gino.all())]
 
 
 @router.get("/request")
@@ -79,18 +82,25 @@ async def list_requests(
 
 
 @router.get("/request/user", status_code=HTTP_200_OK)
-async def list_user_requests(auth=Depends(Auth)) -> dict:
+async def list_user_requests(api_request: Request, auth=Depends(Auth)) -> dict:
     """
     List the current user's requests.
     """
     # no authz checks because we assume the current user can read
     # their own requests.
-
+    active = False
+    if "active" in api_request.query_params:
+        if api_request.query_params["active"]:
+            raise HTTPException(
+                HTTP_400_BAD_REQUEST,
+                f"The 'active' parameter should not be assigned a value. Received '{api_request.query_params['active']}'",
+            )
+        active = True
     token_claims = await auth.get_token_claims()
     username = token_claims["context"]["user"]["name"]
-    logger.debug(f"Getting requests for user '{username}'")
+    logger.debug(f"Getting requests for user '{username}' with active = '{active}'")
 
-    user_requests = await get_user_requests(username)
+    user_requests = await get_user_requests(username, active=active)
     return [r.to_dict() for r in user_requests]
 
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -159,7 +159,7 @@ def test_get_active_user_requests(client):
         "policy_id": "test-final-policy",
         "resource_id": "final",
         "resource_display_name": "My Final Resource",
-        "status": "CANCELLED",
+        "status": config["FINAL_STATUSES"][0],
     }
     res = client.post(
         "/request", json=data, headers={"Authorization": f"bearer {fake_jwt}"}

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -125,6 +125,42 @@ def test_get_user_requests(client):
     assert res.status_code == 401, res.text
 
 
+def test_get_active_user_requests(client):
+    fake_jwt = "1.2.3"
+
+    # create a request with no status
+    data = {
+        "policy_id": "test-draft-policy",
+        "resource_id": "draft_uniqid",
+        "resource_display_name": "My Draft Resource",
+    }
+    res = client.post(
+        "/request", json=data, headers={"Authorization": f"bearer {fake_jwt}"}
+    )
+    assert res.status_code == 201, res.text
+    assert res.json()["status"] in config["DRAFT_STATUSES"]
+
+    # create a request for the current user with an "Active status"
+    data = {
+        "policy_id": "test-active-policy",
+        "resource_id": "active_uniqid",
+        "resource_display_name": "My Active Resource",
+        "status": "APPROVED",
+    }
+    res = client.post(
+        "/request", json=data, headers={"Authorization": f"bearer {fake_jwt}"}
+    )
+    assert res.status_code == 201, res.text
+    user_request = res.json()
+
+    # check that only the request with an "Active Status" is listed
+    res = client.get(
+        "/request/user?active", headers={"Authorization": f"bearer {fake_jwt}"}
+    )
+    assert res.status_code == 200, res.text
+    assert res.json() == [user_request]
+
+
 def test_list_requests_with_access(client):
     fake_jwt = "1.2.3"
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -128,11 +128,12 @@ def test_get_user_requests(client):
 def test_get_active_user_requests(client):
     fake_jwt = "1.2.3"
 
-    # create a request with no status
+    # create a request with a DRAFT status
     data = {
         "policy_id": "test-draft-policy",
         "resource_id": "draft_uniqid",
         "resource_display_name": "My Draft Resource",
+        "status": "CREATED",
     }
     res = client.post(
         "/request", json=data, headers={"Authorization": f"bearer {fake_jwt}"}
@@ -153,6 +154,18 @@ def test_get_active_user_requests(client):
     assert res.status_code == 201, res.text
     user_request = res.json()
 
+    # create a request for the current user with an "Active status"
+    data = {
+        "policy_id": "test-final-policy",
+        "resource_id": "final",
+        "resource_display_name": "My Final Resource",
+        "status": "CANCELLED",
+    }
+    res = client.post(
+        "/request", json=data, headers={"Authorization": f"bearer {fake_jwt}"}
+    )
+    assert res.status_code == 201, res.text
+    assert res.json()["status"] in config["FINAL_STATUSES"]
     # check that only the request with an "Active Status" is listed
     res = client.get(
         "/request/user?active", headers={"Authorization": f"bearer {fake_jwt}"}

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -154,7 +154,7 @@ def test_get_active_user_requests(client):
     assert res.status_code == 201, res.text
     user_request = res.json()
 
-    # create a request for the current user with an "Active status"
+    # create a request with a FINAL status
     data = {
         "policy_id": "test-final-policy",
         "resource_id": "final",

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -139,7 +139,6 @@ def test_get_active_user_requests(client):
         "/request", json=data, headers={"Authorization": f"bearer {fake_jwt}"}
     )
     assert res.status_code == 201, res.text
-    assert res.json()["status"] in config["DRAFT_STATUSES"]
 
     # create a request for the current user with an "Active status"
     data = {

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -133,7 +133,7 @@ def test_get_active_user_requests(client):
         "policy_id": "test-draft-policy",
         "resource_id": "draft_uniqid",
         "resource_display_name": "My Draft Resource",
-        "status": "CREATED",
+        "status": config["DRAFT_STATUSES"][0],
     }
     res = client.post(
         "/request", json=data, headers={"Authorization": f"bearer {fake_jwt}"}

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -165,7 +165,7 @@ def test_get_active_user_requests(client):
         "/request", json=data, headers={"Authorization": f"bearer {fake_jwt}"}
     )
     assert res.status_code == 201, res.text
-    assert res.json()["status"] in config["FINAL_STATUSES"]
+
     # check that only the request with an "Active Status" is listed
     res = client.get(
         "/request/user?active", headers={"Authorization": f"bearer {fake_jwt}"}


### PR DESCRIPTION
Jira Ticket: [PXP-8831](https://ctds-planx.atlassian.net/browse/PXP-8831)

### New Features
* Add a query param `/request/user` to filter only active user requests