### PR TITLE
Error if the policy does not exist

### DIFF
--- a/src/requestor/routes/maintain.py
+++ b/src/requestor/routes/maintain.py
@@ -72,7 +72,6 @@ async def create_request(
 
     resource_paths = None
     client = api_request.app.arborist_client
-    existing_policies = await arborist.list_policies(client, expand=True)
 
     if not data["policy_id"]:
         # fallback to body `resource_path` for backwards compatibility
@@ -80,16 +79,18 @@ async def create_request(
             client, data["resource_path"]
         )
         resource_paths = [data["resource_path"]]
-    elif "revoke" not in api_request.query_params and not arborist.get_policy_for_id(
-        existing_policies["policies"], data["policy_id"]
-    ):
-        # Raise an exception if the policy does not exist in arborist
-        raise HTTPException(
-            HTTP_400_BAD_REQUEST,
-            f"Request creation failed. There is no 'policy_id' - '{data['policy_id']}' in arborist.",
-        )
+    else:
+        existing_policies = await arborist.list_policies(client, expand=True)
 
-    if not resource_paths:
+        if not arborist.get_policy_for_id(
+            existing_policies["policies"], data["policy_id"]
+        ):
+            # Raise an exception if the policy does not exist in arborist
+            raise HTTPException(
+                HTTP_400_BAD_REQUEST,
+                f"Request creation failed. The policy '{data['policy_id']}' does not exist.",
+            )
+
         resource_paths = arborist.get_resource_paths_for_policy(
             existing_policies["policies"], data["policy_id"]
         )
@@ -97,7 +98,9 @@ async def create_request(
     await auth.authorize("create", resource_paths)
 
     request_id = str(uuid.uuid4())
-    logger.debug(f"Creating request. request_id: {request_id}. Received body: {data}")
+    logger.debug(
+        f"Creating request. request_id: {request_id}. Received body: {data}. Revoke: {'revoke' in api_request.query_params}"
+    )
 
     if not data.get("status"):
         data["status"] = config["DEFAULT_INITIAL_STATUS"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -221,22 +221,12 @@ def mock_arborist_requests(request):
                                 "roles": [],
                             },
                             {
-                                "id": "test-draft-policy",
+                                "id": "test-existing-policy",
                                 "resource_paths": [],
                                 "roles": [],
                             },
                             {
-                                "id": "test-active-policy",
-                                "resource_paths": [],
-                                "roles": [],
-                            },
-                            {
-                                "id": "test-final-policy",
-                                "resource_paths": [],
-                                "roles": [],
-                            },
-                            {
-                                "id": "random",
+                                "id": "test-existing-policy-2",
                                 "resource_paths": [],
                                 "roles": [],
                             },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -220,6 +220,26 @@ def mock_arborist_requests(request):
                                 "resource_paths": ["/my/resource"],
                                 "roles": [],
                             },
+                            {
+                                "id": "test-draft-policy",
+                                "resource_paths": [],
+                                "roles": [],
+                            },
+                            {
+                                "id": "test-active-policy",
+                                "resource_paths": [],
+                                "roles": [],
+                            },
+                            {
+                                "id": "test-final-policy",
+                                "resource_paths": [],
+                                "roles": [],
+                            },
+                            {
+                                "id": "random",
+                                "resource_paths": [],
+                                "roles": [],
+                            },
                         ]
                     },
                     204 if authorized else 403,

--- a/tests/test_maintain.py
+++ b/tests/test_maintain.py
@@ -200,6 +200,20 @@ def test_create_request_without_access(client, mock_arborist_requests):
     assert res.json() == []
 
 
+def test_create_request_with_invalid_policy(client):
+    fake_jwt = "1.2.3"
+
+    # attempt to create a request with a policy that is not present in arborist
+    data = {
+        "username": "requestor_user",
+        "policy_id": "some-nonexistent-policy",
+    }
+    res = client.post(
+        "/request", json=data, headers={"Authorization": f"bearer {fake_jwt}"}
+    )
+    assert res.status_code == 400, res.text
+
+
 def test_update_request(client):
     """
     When updating the request with an UPDATE_ACCESS_STATUS, a call

--- a/tests/test_maintain.py
+++ b/tests/test_maintain.py
@@ -13,7 +13,7 @@ def test_create_request_with_resource_path_and_policy(client):
     data = {
         "username": "requestor_user",
         "resource_path": "/test-resource-path/resource",
-        "policy_id": "test_policy",
+        "policy_id": "test-policy",
         "resource_id": "uniqid",
         "resource_display_name": "My Resource",
     }
@@ -200,10 +200,10 @@ def test_create_request_without_access(client, mock_arborist_requests):
     assert res.json() == []
 
 
-def test_create_request_with_invalid_policy(client):
+def test_create_request_with_non_existent_policy(client):
     fake_jwt = "1.2.3"
 
-    # attempt to create a request with a policy that is not present in arborist
+    # attempt to create an access request with a policy that is not present in arborist
     data = {
         "username": "requestor_user",
         "policy_id": "some-nonexistent-policy",
@@ -212,6 +212,18 @@ def test_create_request_with_invalid_policy(client):
         "/request", json=data, headers={"Authorization": f"bearer {fake_jwt}"}
     )
     assert res.status_code == 400, res.text
+    assert "does not exist" in res.text
+
+    # attempt to create a revoke request with a policy that is not present in arborist
+    data = {
+        "username": "requestor_user",
+        "policy_id": "some-nonexistent-policy",
+    }
+    res = client.post(
+        "/request?revoke", json=data, headers={"Authorization": f"bearer {fake_jwt}"}
+    )
+    assert res.status_code == 400, res.text
+    assert "does not exist" in res.text
 
 
 def test_update_request(client):
@@ -464,7 +476,7 @@ def test_revoke_request_failure(client):
     assert "should not be assigned a value" in res.json()["detail"]
 
     # attempt to revoke access to a policy the user doesn't have
-    data["policy_id"] = "super-access"
+    data["policy_id"] = "test-existing-policy"
     res = client.post(
         "/request?revoke", json=data, headers={"Authorization": f"bearer {fake_jwt}"}
     )

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -129,7 +129,7 @@ def test_get_active_user_requests(client):
 
     # create a request with a DRAFT status
     data = {
-        "policy_id": "test-draft-policy",
+        "policy_id": "test-policy",
         "resource_id": "draft_uniqid",
         "resource_display_name": "My Draft Resource",
         "status": config["DRAFT_STATUSES"][0],
@@ -141,7 +141,7 @@ def test_get_active_user_requests(client):
 
     # create a request for the current user with an "Active status"
     data = {
-        "policy_id": "test-active-policy",
+        "policy_id": "test-existing-policy",
         "resource_id": "active_uniqid",
         "resource_display_name": "My Active Resource",
         "status": "APPROVED",
@@ -154,7 +154,7 @@ def test_get_active_user_requests(client):
 
     # create a request with a FINAL status
     data = {
-        "policy_id": "test-final-policy",
+        "policy_id": "test-existing-policy-2",
         "resource_id": "final",
         "resource_display_name": "My Final Resource",
         "status": config["FINAL_STATUSES"][0],
@@ -175,7 +175,8 @@ def test_get_active_user_requests(client):
 def test_get_filtered_user_requests(client):
     fake_jwt = "1.2.3"
     filtered_requests = []
-    # create a request with policy_id test-policy, status = APPROVED and revoke = False
+
+    # create a request with status = APPROVED and revoke = False
     data = {
         "policy_id": "test-policy",
         "resource_id": "draft_uniqid",
@@ -189,9 +190,10 @@ def test_get_filtered_user_requests(client):
     assert res.status_code == 201, res.text
     filtered_requests.append(res.json())
     datetime = filtered_requests[0]["created_time"]
-    # create a request with policy_id test-draft-policy, status = APPROVED and revoke = False
+
+    # create a request with a different policy_id, status = APPROVED and revoke = False
     data = {
-        "policy_id": "test-draft-policy",
+        "policy_id": "test-existing-policy",
         "resource_id": "active_uniqid",
         "revoke": "False",
         "resource_display_name": "My Active Resource",
@@ -205,7 +207,7 @@ def test_get_filtered_user_requests(client):
 
     # create a request with a different policy_id and status but with revoke=False
     data = {
-        "policy_id": "random",
+        "policy_id": "test-existing-policy-2",
         "resource_id": "final",
         "resource_display_name": "My Final Resource",
         "revoke": "False",
@@ -226,7 +228,7 @@ def test_get_filtered_user_requests(client):
 
     # Add mulitple values to a single key to test 'or' functionality alongside 'and'
     res = client.get(
-        f"/request/user?policy_id=test-policy&policy_id=test-draft-policy&status=APPROVED&created_time={datetime}",
+        f"/request/user?policy_id=test-policy&policy_id=test-existing-policy&status=APPROVED&created_time={datetime}",
         headers={"Authorization": f"bearer {fake_jwt}"},
     )
     assert res.status_code == 200, res.text

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -175,9 +175,9 @@ def test_get_active_user_requests(client):
 def test_get_filtered_user_requests(client):
     fake_jwt = "1.2.3"
     filtered_requests = []
-    # create a request with policy_id foo, status = APPROVED and revoke = False
+    # create a request with policy_id test-policy, status = APPROVED and revoke = False
     data = {
-        "policy_id": "foo",
+        "policy_id": "test-policy",
         "resource_id": "draft_uniqid",
         "revoke": "False",
         "resource_display_name": "My Draft Resource",
@@ -189,10 +189,9 @@ def test_get_filtered_user_requests(client):
     assert res.status_code == 201, res.text
     filtered_requests.append(res.json())
     datetime = filtered_requests[0]["created_time"]
-
-    # create a request with policy_id bar, status = APPROVED and revoke = False
+    # create a request with policy_id test-draft-policy, status = APPROVED and revoke = False
     data = {
-        "policy_id": "bar",
+        "policy_id": "test-draft-policy",
         "resource_id": "active_uniqid",
         "revoke": "False",
         "resource_display_name": "My Active Resource",
@@ -227,7 +226,7 @@ def test_get_filtered_user_requests(client):
 
     # Add mulitple values to a single key to test 'or' functionality alongside 'and'
     res = client.get(
-        f"/request/user?policy_id=foo&policy_id=bar&status=APPROVED&created_time={datetime}",
+        f"/request/user?policy_id=test-policy&policy_id=test-draft-policy&status=APPROVED&created_time={datetime}",
         headers={"Authorization": f"bearer {fake_jwt}"},
     )
     assert res.status_code == 200, res.text


### PR DESCRIPTION


### Improvements
- Return an error if the policy the user is trying to request or revoke does not exist
- Consolidate policy IDs in unit tests into a few reusable "existing" policy IDs
