### PR TITLE
(fix): Handle request_paths without content after slash ('/')

### DIFF
--- a/src/requestor/routes/manage.py
+++ b/src/requestor/routes/manage.py
@@ -112,6 +112,12 @@ async def create_request(
     client = api_request.app.arborist_client
 
     if not data["policy_id"]:
+        # Check format of resource_paths (should have content after slash)
+        for p in data["resource_paths"]:
+            if not p.split("/")[1:]:
+                msg = f"Request creation failed. Resource path '{p}' does not have content after a forward slash ('/')."
+                raise_error(logger, msg, body)
+
         if data.get("role_ids") and data.get("resource_paths"):
 
             existing_roles = await arborist.list_roles(client)

--- a/tests/test_manage_resource_path.py
+++ b/tests/test_manage_resource_path.py
@@ -117,9 +117,26 @@ def test_get_auto_policy_id_for_resource_paths_and_role_ids(client, data):
             "resource_display_name": "My Resource",
             "err_msg": "The request cannot have both role_ids and policy_id",
         },
+        {
+            # resource_path without slash
+            "username": "requestor_user",
+            "resource_path": "path-without-slash",
+            "resource_id": "uniqid",
+            "resource_display_name": "My Resource",
+            "err_msg": "does not have content after a forward slash",
+        },
+        {
+            # resource_paths without slash
+            "username": "requestor_user",
+            "role_ids": ["study_registrant"],
+            "resource_paths": ["path-without-slash"],
+            "resource_id": "uniqid",
+            "resource_display_name": "My Resource",
+            "err_msg": "does not have content after a forward slash",
+        },
     ],
 )
-def test_create_request_with_unallowed_params(client, data):
+def test_create_request_with_unallowed_params(client, list_roles_patcher, data):
     """
     When a user attempts to create a request with
         - role_ids without resource_paths

--- a/tests/test_query_resource_path.py
+++ b/tests/test_query_resource_path.py
@@ -137,7 +137,7 @@ def test_list_requests_with_access(client):
 
     # create requests
     request_data = {}
-    for resource_path in ["/my/resource", "something-i-cant-access"]:
+    for resource_path in ["/my/resource", "/something-i-cant-access"]:
         data = {
             "resource_path": resource_path,
             "resource_id": "uniqid",
@@ -151,7 +151,7 @@ def test_list_requests_with_access(client):
 
     # list requests
     # the mocked auth_mapping response in mock_arborist_requests does not
-    # include "something-i-cant-access", so it should not be returned
+    # include "/something-i-cant-access", so it should not be returned
     res = client.get("/request", headers={"Authorization": f"bearer {fake_jwt}"})
     assert res.status_code == 200, res.text
     assert res.json() == [request_data["/my/resource"]]


### PR DESCRIPTION
Jira Ticket: None

### New Features


### Breaking Changes


### Bug Fixes

* Handle resource_paths without content after a forward slash ('/')


### Improvements


### Dependency updates


### Deployment changes

