### PR TITLE
fix: update param to list in call in migration

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -90,7 +90,7 @@ components:
       type: http
 info:
   title: Requestor
-  version: 1.5.1
+  version: 1.7.0
 openapi: 3.0.2
 paths:
   /_status:

--- a/migrations/versions/42cbae986650_policy_id_and_revoke.py
+++ b/migrations/versions/42cbae986650_policy_id_and_revoke.py
@@ -66,7 +66,7 @@ def upgrade():
     for resource_path in existing_resource_paths:
         policy_id = get_auto_policy_id_for_resource_path(resource_path)
         if not config["LOCAL_MIGRATION"] and policy_id not in existing_policies:
-            create_arborist_policy(arborist_client, resource_path)
+            create_arborist_policy(arborist_client, [resource_path])
         connection.execute(
             f"UPDATE requests SET policy_id='{escape(policy_id)}', revoke=False WHERE resource_path='{escape(resource_path)}'"
         )


### PR DESCRIPTION
Jira Ticket: none

### New Features


### Breaking Changes


### Bug Fixes

* Update param in call to `create_arborist_policy` in migrations to match new signature of method. 

### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
