### PR TITLE
PXP-10113 Support "client credentials" tokens

### DIFF
--- a/src/requestor/routes/manage.py
+++ b/src/requestor/routes/manage.py
@@ -158,7 +158,12 @@ async def create_request(
     if not data.get("username"):
         logger.debug("No username provided in body, using token username")
         token_claims = await auth.get_token_claims()
-        token_username = token_claims["context"]["user"]["name"]
+        token_username = token_claims.get("context", {}).get("user", {}).get("name")
+        if not token_username:
+            raise HTTPException(
+                HTTP_400_BAD_REQUEST,
+                "Must provide a username in the request body or token",
+            )
         logger.debug(f"Got username from token: {token_username}")
         data["username"] = token_username
 

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -227,7 +227,7 @@ def test_backoff_retry(client):
         assert mock_requests.post.call_count == config["DEFAULT_MAX_RETRIES"]
 
 
-def test_create_request_failure_revert(client):
+def test_create_request_failure_revert(client, access_token_user_only_patcher):
     """
     If something goes wrong during an external call, access should not be
     granted, the request should not be created and we should get a 500.

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -43,7 +43,7 @@ def test_create_request_with_unallowed_params(client, data):
     assert data["err_msg"] in res.json()["detail"]
 
 
-def test_create_request_without_username(client):
+def test_create_request_without_username(client, access_token_user_only_patcher):
     """
     When a username is not provided in the body, the request is created
     using the username from the provided access token.
@@ -146,7 +146,9 @@ def test_create_duplicate_request(client):
     assert res.status_code == 201, res.text
 
 
-def test_create_request_without_access(client, mock_arborist_requests):
+def test_create_request_without_access(
+    client, mock_arborist_requests, access_token_user_only_patcher
+):
     fake_jwt = "1.2.3"
     mock_arborist_requests(authorized=False)
 

--- a/tests/test_manage_resource_path.py
+++ b/tests/test_manage_resource_path.py
@@ -287,7 +287,7 @@ def test_create_request_with_resource_paths_and_role_ids(
         },
     ],
 )
-def test_create_request_without_username(client, data):
+def test_create_request_without_username(client, data, access_token_user_only_patcher):
     """
     When a username is not provided in the body, the request is created
     using the username from the provided access token.
@@ -441,7 +441,11 @@ def test_create_duplicate_request(client, data):
     ],
 )
 def test_create_request_without_access(
-    client, mock_arborist_requests, list_roles_patcher, data
+    client,
+    mock_arborist_requests,
+    list_roles_patcher,
+    data,
+    access_token_user_only_patcher,
 ):
     fake_jwt = "1.2.3"
     mock_arborist_requests(authorized=False)

--- a/tests/test_query_resource_path.py
+++ b/tests/test_query_resource_path.py
@@ -10,7 +10,7 @@ from requestor.arborist import get_auto_policy_id_for_resource_path
 from requestor.config import config
 
 
-def test_create_get_and_list_request(client):
+def test_create_get_and_list_request(client, access_token_user_only_patcher):
     fake_jwt = "1.2.3"
 
     # list requests: empty
@@ -99,7 +99,7 @@ def test_get_request_without_access(client, mock_arborist_requests):
     assert not_found_err == unauthorized_err
 
 
-def test_get_user_requests(client):
+def test_get_user_requests(client, access_token_user_only_patcher):
     fake_jwt = "1.2.3"
 
     # create a request for the current user
@@ -132,7 +132,7 @@ def test_get_user_requests(client):
     assert res.status_code == 401, res.text
 
 
-def test_list_requests_with_access(client):
+def test_list_requests_with_access(client, access_token_user_only_patcher):
     fake_jwt = "1.2.3"
 
     # create requests
@@ -190,7 +190,9 @@ def test_list_requests_with_access(client):
         },
     ],
 )
-def test_check_user_resource_paths_prefixes(client, list_policies_patcher, test_data):
+def test_check_user_resource_paths_prefixes(
+    client, list_policies_patcher, test_data, access_token_user_only_patcher
+):
     """
     Test if having requested access to the resource path in
     test_data["resource_path"] means having requested access to
@@ -227,7 +229,9 @@ def test_check_user_resource_paths_prefixes(client, list_policies_patcher, test_
 
 
 @pytest.mark.parametrize("test_data", [{"resource_paths": ["/a/b", "/c"]}])
-def test_check_user_resource_paths_multiple(client, list_policies_patcher, test_data):
+def test_check_user_resource_paths_multiple(
+    client, list_policies_patcher, test_data, access_token_user_only_patcher
+):
     fake_jwt = "1.2.3"
     existing_resource_paths = test_data["resource_paths"]
     expected_matches = {
@@ -262,7 +266,7 @@ def test_check_user_resource_paths_multiple(client, list_policies_patcher, test_
     assert res.json() == expected_matches
 
 
-def test_check_user_resource_paths_username(client):
+def test_check_user_resource_paths_username(client, access_token_user_only_patcher):
     fake_jwt = "1.2.3"
 
     resource_path_to_match = "/a/b"
@@ -312,7 +316,9 @@ def test_check_user_resource_paths_username(client):
         },
     ],
 )
-def test_check_user_resource_paths_status(client, list_policies_patcher, test_data):
+def test_check_user_resource_paths_status(
+    client, list_policies_patcher, test_data, access_token_user_only_patcher
+):
     fake_jwt = "1.2.3"
     resource_path_to_match = test_data["resource_path"]
 


### PR DESCRIPTION
Jira Ticket: [PXP-10113](https://ctds-planx.atlassian.net/browse/PXP-10113)

### New Features
- Support "client credentials" tokens that are not linked to a user in all endpoints, except those that specifically query users' requests, and the "list requests" endpoint which will be updated at a later time
