### PR TITLE
Status mismatch prevents reusing a draft request

### DIFF
--- a/src/requestor/routes/manage.py
+++ b/src/requestor/routes/manage.py
@@ -238,6 +238,18 @@ async def create_request(
             f"Found a draft request with request_id: {draft_previous_requests[0].request_id}"
         )
         request = draft_previous_requests[0]
+        if request.status != data["status"]:
+            msg = f'A draft access request for username \'{data["username"]}\' and policy_id \'{data["policy_id"]}\' in status \'{request.status}\' already exists. Use the update endpoint instead if you want to update the status to \'{data["status"]}\'.'
+            logger.error(
+                msg
+                + f" body: {data}. existing requests: {[r.request_id for r in previous_requests]}",
+                exc_info=True,
+            )
+            raise HTTPException(
+                HTTP_409_CONFLICT,
+                msg,
+            )
+
     else:
         # create a new request
         data = {"request_id": request_id, **data}

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -87,6 +87,15 @@ def test_create_duplicate_request(client):
     new_request_id = request_data.get("request_id")
     assert new_request_id == request_id
 
+    # create a request with the same username and policy_id, but a new status.
+    # since the status does not match, it should fail.
+    res = client.post(
+        "/request",
+        json={**data, "status": "INTERMEDIATE_STATUS"},
+        headers={"Authorization": f"bearer {fake_jwt}"},
+    )
+    assert res.status_code == 409, res.text
+
     # update the orignal request's status to a non-final, non-draft status
     res = client.put(f"/request/{request_id}", json={"status": "INTERMEDIATE_STATUS"})
     assert res.status_code == 200, res.text


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one:

### New Features

### Breaking Changes

### Bug Fixes

### Improvements
- A status mismatch now prevents updating an existing draft access request

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
